### PR TITLE
Added support for ACF options pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ It returns a JSON response with the following (returns an empty array if no post
 - title
 - Yoast SEO fields, if applicable
 
+### ACF Options
+**`better-rest-endpoints/v1/options/acf`**
+Gets an array of all ACF Options Page fields, returns an empty array if none are found or if ACF is not active.
+
+**`better-rest-endpoints/v1/options/acf/{field}`**
+Gets a single ACF Options Page field, returns null if ACF is not active or the field does not exist.
+
+Accepts the following parameters:
+
+- field (string - can be either the field key or the field name)
+
 ## Hooks and Filters
 
 ### Filter the Custom Post Types endpoints

--- a/better-rest-endpoints.php
+++ b/better-rest-endpoints.php
@@ -118,6 +118,9 @@ class F1_Better_Rest_Endpoints {
 
 		// get taxonomies endpoint
 		include_once self::$plugin_dir . 'includes/get_taxonomies.php';
+
+		// get acf option endpoint
+		include_once self::$plugin_dir . 'includes/get_options_acf.php';
 	}
 
 }

--- a/includes/get_options_acf.php
+++ b/includes/get_options_acf.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Retrieve single ACF options page value
+ *
+ * @param WP_REST_Request $request
+ * @return array|void
+ * @since 1.3.0
+ */
+function get_options_acf_single( WP_REST_Request $request ){
+    include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+    // Only run if we have ACF installed
+    if( !is_plugin_active('advanced-custom-fields-pro/acf.php') && !is_plugin_active('advanced-custom-fields/acf.php') ) {
+        return;
+    }
+
+    if($field = get_field($request['field'], 'option')) {
+        return $field;
+    } else {
+        return;
+    }
+}
+
+/**
+ * Retrieve array of all ACF options page values
+ *
+ * @return array
+ * @since 1.3.0
+ */
+function get_options_acf_all(){
+    include_once ( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+    // Only run if we have ACF installed
+    if( !is_plugin_active('advanced-custom-fields-pro/acf.php') && !is_plugin_active('advanced-custom-fields/acf.php') ) {
+        return array();
+    }
+
+    return get_fields('options');
+}
+
+/**
+ * Register REST APIs
+ */
+add_action( 'rest_api_init', function () {
+    register_rest_route( 'better-rest-endpoints/v1', '/options/acf', array(
+        'methods' => 'GET',
+        'callback' => 'get_options_acf_all',
+    ));
+    register_rest_route( 'better-rest-endpoints/v1', '/options/acf/(?P<field>\S+)', array(
+        'methods' => 'GET',
+        'callback' => 'get_options_acf_single',
+    ));
+});


### PR DESCRIPTION
Added endpoints for single ACF options field and endpoint for all ACF option fields.

Used /options/acf to leave room for possibility of other options endpoints being added at a later date.

Was unsure as to why the include for includes/plugin.php had been included. I assumed this was for the plugin being used with a minimal WP load, so it has been included as this will not have an impact if added.