### PR TITLE
Add 'modified date' to all endpoints with 'date'

### DIFF
--- a/includes/create_cpt_endpoints.php
+++ b/includes/create_cpt_endpoints.php
@@ -77,6 +77,7 @@ function bre_build_cpt_endpoints() {
                 $bre_post->slug = $post->post_name;
                 $bre_post->permalink = $permalink;
                 $bre_post->date = get_the_date('c');
+                $bre_post->date_modified = get_the_modified_date('c');
                 $bre_post->excerpt = get_the_excerpt();
 
                 // show post content unless parameter is false

--- a/includes/get_cpt_by_id.php
+++ b/includes/get_cpt_by_id.php
@@ -53,6 +53,7 @@ function bre_build_single_cpt_endpoints() {
                 $bre_cpt_post->slug = $post->post_name;
                 $bre_cpt_post->permalink = $permalink;
                 $bre_cpt_post->date = get_the_date('c');
+                $bre_cpt_post->date_modified = get_the_modified_date('c');
                 $bre_cpt_post->excerpt = get_the_excerpt();
                 $bre_cpt_post->content = apply_filters('the_content', get_the_content());
                 $bre_cpt_post->author = esc_html__(get_the_author(), 'text_domain');

--- a/includes/get_cpt_by_slug.php
+++ b/includes/get_cpt_by_slug.php
@@ -53,6 +53,7 @@ function bre_build_single_cpt_endpoints_slug() {
                 $bre_cpt_post->slug = $post->post_name;
                 $bre_cpt_post->permalink = $permalink;
                 $bre_cpt_post->date = get_the_date('c');
+                $bre_cpt_post->date_modified = get_the_modified_date('c');
                 $bre_cpt_post->excerpt = get_the_excerpt();
                 $bre_cpt_post->content = apply_filters('the_content', get_the_content());
                 $bre_cpt_post->author = esc_html__(get_the_author(), 'text_domain');

--- a/includes/get_post_by_id.php
+++ b/includes/get_post_by_id.php
@@ -32,6 +32,7 @@ function get_post_by_id( $data ) {
       $bre_post->slug = $post->post_name;
       $bre_post->permalink = $permalink;
       $bre_post->date = get_the_date('c');
+      $bre_post->date_modified = get_the_modified_date('c');
       $bre_post->excerpt = get_the_excerpt();
       $bre_post->content = apply_filters('the_content', get_the_content());
       $bre_post->author = esc_html__(get_the_author(), 'text_domain');

--- a/includes/get_post_by_slug.php
+++ b/includes/get_post_by_slug.php
@@ -34,6 +34,7 @@ function get_post_by_slug( WP_REST_Request $request ) {
       $bre_post->slug = $post->post_name;
       $bre_post->permalink = $permalink;
       $bre_post->date = get_the_date('c');
+      $bre_post->date_modified = get_the_modified_date('c');
       $bre_post->excerpt = get_the_excerpt();
       $bre_post->content = apply_filters('the_content', get_the_content());
       $bre_post->author = esc_html__(get_the_author(), 'text_domain');

--- a/includes/get_posts.php
+++ b/includes/get_posts.php
@@ -69,6 +69,7 @@ function bre_get_posts( WP_REST_Request $request ) {
       $bre_post->slug = $post->post_name;
       $bre_post->permalink = $permalink;
       $bre_post->date = get_the_date('c');
+      $bre_post->date_modified = get_the_modified_date('c');
       $bre_post->excerpt = get_the_excerpt();
 
       // show post content unless parameter is false

--- a/includes/get_posts_tax.php
+++ b/includes/get_posts_tax.php
@@ -88,6 +88,7 @@ function bre_build_custom_tax_endpoint() {
                   $bre_tax_post->slug = $post->post_name;
                   $bre_tax_post->permalink = $permalink;
                   $bre_tax_post->date = get_the_date('c');
+                  $bre_tax_post->date_modified = get_the_modified_date('c');
                   $bre_tax_post->excerpt = get_the_excerpt();
 
                   if( $content === null || $show_content === true ){

--- a/includes/get_search.php
+++ b/includes/get_search.php
@@ -61,6 +61,7 @@ function bre_get_search( WP_REST_Request $request ) {
       $bre_post->slug = $post->post_name;
       $bre_post->permalink = $permalink;
       $bre_post->date = get_the_date('c');
+      $bre_post->date_modified = get_the_modified_date('c');
       $bre_post->excerpt = get_the_excerpt();
 
       // show post content unless parameter is false


### PR DESCRIPTION
A very simple change to add the relevant post's "modified date" string into the response object, alongside the existing "published date" string.

```
{
  id: 1,
  title: "Hello world!",
  slug: "hello-world",
  permalink: "https://justanotherwordpresssite.com.au/hello-world/",
  date: "2018-04-11T04:21:45+00:00",
  date_modified: "2018-11-27T13:07:25+00:00",
  // the rest of the response object
}
```

This is required in situations like mine (building a JS-driven, headless frontend using BRE for data fetching) for generating some SEO-related meta tags for letting search engines know when an article was last updated, not just when it was first published.

Example:
```
<meta property="article:published_time" content="2018-04-11T04:21:45+00:00" />
<meta property="article:modified_time" content="2018-11-27T02:32:47+00:00" />
```