### PR TITLE
Setup a new menu endpoint /menus/location/{theme_location} to match t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,11 +251,27 @@ Returns the following JSON Response:
 - title
 - Yoast SEO Fields, if applicable
 
-### Menus
+### Menus from slug (name)
 **`better-rest-endpoints/v1/menus/{menu-slug}`**
 Gets a WordPress Menu by slug. Accepts no parameters.
 
 Returns the following JSON Response in each item object:
+
+- classes (array)
+- description
+- ID
+- menu item parent
+- menu_order
+- slug
+- target
+- title
+- url
+
+### Menus from location (theme location)
+**`better-rest-endpoints/v1/menus/{menu-slug}`**
+Gets a WordPress Menu by the theme location. Accepts no parameters.
+
+Returns an empty array if the location can not be found or if it has no assigned menu. Returns an array of the following objects if a menu is assigned to the specified location:
 
 - classes (array)
 - description

--- a/better-rest-endpoints.php
+++ b/better-rest-endpoints.php
@@ -107,8 +107,11 @@ class F1_Better_Rest_Endpoints {
 		// get custom post type by slug
 		include_once self::$plugin_dir . 'includes/get_cpt_by_slug.php';
 
-    // get custom post type by id
-		include_once self::$plugin_dir . 'includes/wp_nav_menus.php';
+    	// get menus by menu name
+		include_once self::$plugin_dir . 'includes/wp_nav_menus_by_name.php';
+
+    	// get menus by menu location
+		include_once self::$plugin_dir . 'includes/wp_nav_menus_by_location.php';
 
 		// get custom taxonomies
 		include_once self::$plugin_dir . 'includes/get_tax.php';

--- a/includes/wp_nav_menus_by_location.php
+++ b/includes/wp_nav_menus_by_location.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Get WordPress Nav Menus by Location
+ *
+ * @param N/A
+ * @return object|null Return wp_nav_menu object,  * or null if none.
+ * @since 0.1.1
+ */
+
+function get_menus_by_location( WP_REST_Request $request ) {
+    $location = $request['location'];
+
+    $theme_locations = get_nav_menu_locations();
+
+    if( !array_key_exists($location, $theme_locations) ){
+      return [];
+    }
+
+    $menu = wp_get_nav_menu_items($theme_locations[$location]);
+
+    return array_map(function($row){
+        $items = new stdClass();
+        $items->ID = $row->ID;
+        $items->menu_order = $row->menu_order;
+        $items->title = $row->title;
+        $items->slug = basename($row->url);
+        $items->url = $row->url;
+        $items->target = $row->target;
+        $items->description = $row->description;
+        $items->classes = $row->classes;
+        $items->menu_item_parent = $row->menu_item_parent;
+
+        return $items;
+    }, $menu);
+}
+
+add_action( 'rest_api_init', function () {
+  register_rest_route( 'better-rest-endpoints/v1', '/menus/location/(?P<location>\S+)', array(
+    'methods' => 'GET',
+    'callback' => 'get_menus_by_location',
+  ) );
+} );

--- a/includes/wp_nav_menus_by_name.php
+++ b/includes/wp_nav_menus_by_name.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Get WordPress Nav Menus
+ * Get WordPress Nav Menus By Name
  *
  * @param N/A
  * @return object|null Return wp_nav_menu object,  * or null if none.


### PR DESCRIPTION
I needed to be able to get a menu by the assigned location in a way that a client couldn't come along and rename a menu or swap in a new one. So I added a new endpoint for /menus/location/{location} that will pull what ever menu is assigned to that location.

I kept the same functionality as in the existing menus return, by default it gave more and better information but for consistency I made it match for now. I may go back later and make them both use the same simplified and faster call to get the extended data set and make them work for nested.