### PR TITLE
use get_the_terms with tax strings

### DIFF
--- a/includes/create_cpt_endpoints.php
+++ b/includes/create_cpt_endpoints.php
@@ -96,8 +96,12 @@ function bre_build_cpt_endpoints() {
                  */
                 if( get_object_taxonomies($cpt) ){
                   $cpt_taxonomies = get_object_taxonomies($cpt, 'names');
+                  $terms = array();
 
-                  $bre_post->terms = get_the_terms(get_the_ID(), $cpt_taxonomies);
+                  foreach ( $cpt_taxonomies as $cpt_taxonomy ) {
+                    $terms[] = get_the_terms(get_the_ID(), $cpt_taxonomy);
+                  }
+                  $bre_post->terms = $terms;
 
                 } else {
                   $bre_post->terms = array();

--- a/includes/create_cpt_endpoints.php
+++ b/includes/create_cpt_endpoints.php
@@ -94,17 +94,16 @@ function bre_build_cpt_endpoints() {
                  * get the terms
                  *
                  */
+                $bre_post->terms = array();
                 if( get_object_taxonomies($cpt) ){
                   $cpt_taxonomies = get_object_taxonomies($cpt, 'names');
-                  $terms = array();
 
                   foreach ( $cpt_taxonomies as $cpt_taxonomy ) {
-                    $terms[] = get_the_terms(get_the_ID(), $cpt_taxonomy);
+                    $these_terms = get_the_terms(get_the_ID(), $cpt_taxonomy);
+                    if (false !== $these_terms) {
+                      $bre_post->terms = array_merge($bre_post->terms, $these_terms);
+                    }
                   }
-                  $bre_post->terms = $terms;
-
-                } else {
-                  $bre_post->terms = array();
                 }
 
                 /*

--- a/includes/get_cpt_by_id.php
+++ b/includes/get_cpt_by_id.php
@@ -65,15 +65,16 @@ function bre_build_single_cpt_endpoints() {
                  * get the terms
                  *
                  */
+                $bre_cpt_post->terms = array();
                 if( get_object_taxonomies($cpt) ){
                   $cpt_taxonomies = get_object_taxonomies($cpt, 'names');
-
-                  $bre_cpt_post->terms = get_the_terms(get_the_ID(), $cpt_taxonomies);
-
-                } else {
-                  $bre_cpt_post->terms = array();
+                  foreach ($cpt_taxonomies as $cpt_taxonomy) {
+                    $these_terms = get_the_terms(get_the_ID(), $cpt_taxonomy);
+                    if (false !== $these_terms) {
+                      $bre_cpt_post->terms = array_merge($bre_cpt_post->terms, $these_terms);
+                    }
+                  }
                 }
-
 
                 /*
                  *

--- a/includes/get_cpt_by_slug.php
+++ b/includes/get_cpt_by_slug.php
@@ -65,15 +65,16 @@ function bre_build_single_cpt_endpoints_slug() {
                  * get the terms
                  *
                  */
+                $bre_cpt_post->terms = array();
                 if( get_object_taxonomies($cpt) ){
                   $cpt_taxonomies = get_object_taxonomies($cpt, 'names');
-
-                  $bre_cpt_post->terms = get_the_terms(get_the_ID(), $cpt_taxonomies);
-
-                } else {
-                  $bre_cpt_post->terms = array();
+                  foreach ($cpt_taxonomies as $cpt_taxonomy) {
+                    $these_terms = get_the_terms(get_the_ID(), $cpt_taxonomy);
+                    if (false !== $these_terms) {
+                      $bre_cpt_post->terms = array_merge($bre_cpt_post->terms, $these_terms);
+                    }
+                  }
                 }
-
 
                 /*
                  *


### PR DESCRIPTION
Thanks for the plugin!

I was getting a bunch of `Notice: Array to string conversion in …/wp-includes/taxonomy.php on line 3306` errors and tracked it down to using an array of taxonomy names with `get_the_terms()`, which expects a single taxonomy name.

I’m guessing at some point this used to use `wp_get_object_terms()` which **does** accept an array, but was changed to `get_the_terms()` for better performance.