### PR TITLE
pass post_id to ACF get_fields function

### DIFF
--- a/includes/create_cpt_endpoints.php
+++ b/includes/create_cpt_endpoints.php
@@ -109,7 +109,7 @@ function bre_build_cpt_endpoints() {
                  *
                  */
                 if( $acf === null || $show_acf === true ) {
-                  $bre_post->acf = bre_get_acf();
+                  $bre_post->acf = bre_get_acf($bre_post->id);
                 }
 
                 /*

--- a/includes/get_acf.php
+++ b/includes/get_acf.php
@@ -7,12 +7,16 @@
  * @since 0.0.1
  */
 
-function bre_get_acf($post_id) {
+function bre_get_acf($post_id = null) {
 
   include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
   // check if acf is active before doing anything
    if( is_plugin_active('advanced-custom-fields-pro/acf.php') || is_plugin_active('advanced-custom-fields/acf.php') ) {
+
+    if ( is_null( $post_id ) ) {
+      $post_id = get_the_ID();
+    }
 
      // get fields
      $acf_fields = get_fields($post_id);

--- a/includes/get_acf.php
+++ b/includes/get_acf.php
@@ -7,15 +7,15 @@
  * @since 0.0.1
  */
 
-function bre_get_acf() {
-  
+function bre_get_acf($post_id) {
+
   include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
   // check if acf is active before doing anything
    if( is_plugin_active('advanced-custom-fields-pro/acf.php') || is_plugin_active('advanced-custom-fields/acf.php') ) {
 
      // get fields
-     $acf_fields = get_fields();
+     $acf_fields = get_fields($post_id);
 
      // if we have fields
      if( $acf_fields ) {

--- a/includes/get_cpt_by_id.php
+++ b/includes/get_cpt_by_id.php
@@ -80,7 +80,7 @@ function bre_build_single_cpt_endpoints() {
                  * return acf fields if they exist
                  *
                  */
-                $bre_cpt_post->acf = bre_get_acf();
+                $bre_cpt_post->acf = bre_get_acf( $bre_cpt_post->id );
 
                 /*
                  *

--- a/includes/get_cpt_by_slug.php
+++ b/includes/get_cpt_by_slug.php
@@ -80,7 +80,7 @@ function bre_build_single_cpt_endpoints_slug() {
                  * return acf fields if they exist
                  *
                  */
-                $bre_cpt_post->acf = bre_get_acf();
+                $bre_cpt_post->acf = bre_get_acf( $bre_cpt_post->id );
 
                 /*
                  *

--- a/includes/get_page_by_id.php
+++ b/includes/get_page_by_id.php
@@ -66,7 +66,7 @@ function get_page_by_id( WP_REST_Request $request ){
        * return acf fields if they exist
        *
        */
-      $bre_page->acf = bre_get_acf();
+      $bre_page->acf = bre_get_acf( $bre_page->id );
 
       /*
        *

--- a/includes/get_page_by_slug.php
+++ b/includes/get_page_by_slug.php
@@ -98,7 +98,7 @@ function get_page_by_slug( WP_REST_Request $request ){
          * return acf fields if they exist
          *
          */
-        $bre_post->acf = bre_get_acf();
+        $bre_post->acf = bre_get_acf( $bre_post->id );
 
         /*
          *

--- a/includes/get_pages.php
+++ b/includes/get_pages.php
@@ -106,7 +106,7 @@ function bre_get_pages( WP_REST_Request $request ) {
        *
        */
        if( $acf === null || $show_acf === true ) {
-         $bre_page->acf = bre_get_acf();
+         $bre_page->acf = bre_get_acf( $bre_page->id );
        }
 
       /*

--- a/includes/get_post_by_id.php
+++ b/includes/get_post_by_id.php
@@ -84,7 +84,7 @@ function get_post_by_id( $data ) {
        * return acf fields if they exist
        *
        */
-      $bre_post->acf = bre_get_acf();
+      $bre_post->acf = bre_get_acf( $bre_post->id );
 
       /*
        *

--- a/includes/get_post_by_slug.php
+++ b/includes/get_post_by_slug.php
@@ -86,7 +86,7 @@ function get_post_by_slug( WP_REST_Request $request ) {
        * return acf fields if they exist
        *
        */
-      $bre_post->acf = bre_get_acf();
+      $bre_post->acf = bre_get_acf( $bre_post->id );
 
       /*
        *

--- a/includes/get_posts.php
+++ b/includes/get_posts.php
@@ -128,7 +128,7 @@ function bre_get_posts( WP_REST_Request $request ) {
        *
        */
       if( $acf === null || $show_acf === true ) {
-        $bre_post->acf = bre_get_acf();
+        $bre_post->acf = bre_get_acf( $bre_post->id );
       }
 
       /*

--- a/includes/get_posts_tax.php
+++ b/includes/get_posts_tax.php
@@ -119,7 +119,7 @@ function bre_build_custom_tax_endpoint() {
                    *
                    */
                    if( $acf === null || $show_acf === true ) {
-                     $bre_tax_post->acf = bre_get_acf();
+                     $bre_tax_post->acf = bre_get_acf( $bre_tax_post->id );
                    }
 
                   /*

--- a/includes/get_search.php
+++ b/includes/get_search.php
@@ -120,7 +120,7 @@ function bre_get_search( WP_REST_Request $request ) {
        *
        */
       if( $acf === null || $show_acf === true ) {
-        $bre_post->acf = bre_get_acf();
+        $bre_post->acf = bre_get_acf( $bre_post->id );
       }
 
       /*


### PR DESCRIPTION
Adds support for passing the current post ID to get more relevant ACF fields.

Starter requirement for adding support for https://hookturn.io/downloads/acf-custom-database-tables/